### PR TITLE
feat(devops): add robust Docker + Poetry setup with dev/prod modes, n…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,50 +1,81 @@
-# ===== Base image =====
-FROM python:3.13-slim AS base
 
-# ===== System dependencies =====
-RUN apt-get update && apt-get install -y \
-    curl \
-    git \
-    build-essential \
- && rm -rf /var/lib/apt/lists/*
+# syntax=docker/dockerfile:1.4
+ARG PYTHON_VERSION=3.13
+ARG POETRY_VERSION=1.6.0
+ARG APP_USER=jdin
+ARG APP_UID=1001
+ARG APP_GID=1001
 
-# ===== Install Poetry =====
-ENV POETRY_HOME="/opt/poetry"
-ENV PATH="$POETRY_HOME/bin:$PATH"
-RUN curl -sSL https://install.python-poetry.org | python3 -
+########################
+### Builder stage
+########################
+FROM python:${PYTHON_VERSION}-slim AS builder
 
-# ===== Set working directory =====
-WORKDIR "/workspaces/jdinbot"
+# essential build deps
+ENV DEBIAN_FRONTEND=noninteractive \
+    POETRY_HOME=/opt/poetry \
+    PATH=/opt/poetry/bin:$PATH \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
-# ===== Copy dependency files first (caching) =====
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl build-essential git gcc libpq-dev ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry (official installer)
+RUN curl -sSL https://install.python-poetry.org | python3 - \
+  && poetry --version
+
+WORKDIR /app
+
+# Copy only dependency manifests first for caching
 COPY pyproject.toml poetry.lock* /app/
 
-# ===== Build argument to switch modes =====
-ARG DEV_MODE=true
+# Use BuildKit cache for Poetry caches (speeds up repeated builds)
+RUN --mount=type=cache,target=/root/.cache/pypoetry \
+    poetry config virtualenvs.create false \
+ && --mount=type=cache,target=/root/.cache/pip \
+    poetry install --no-interaction --no-ansi --only main
 
-# ===== Install dependencies =====
-RUN if [ "$DEV_MODE" = "true" ]; then \
-        # Dev mode: virtualenv inside project \
-        poetry config virtualenvs.in-project true && \
-        poetry install --no-root --only main; \
-    else \
-        # Prod mode: global installation \
-        poetry config virtualenvs.create false && \
-        poetry install --no-root --only main; \
-    fi
-
-# ===== Copy source code =====
+# Copy rest of the project
 COPY . /app
 
-# ===== Install current project =====
-RUN if [ "$DEV_MODE" = "true" ]; then \
-        poetry install --editable; \
-    else \
-        poetry install; \
-    fi
+# (optional) run tests / build steps for compiled deps here
 
-# ===== Default command =====
-CMD ["poetry", "run", "python", "bot.py"]  # adjust to your entry script
+########################
+### Runtime stage
+########################
+FROM python:${PYTHON_VERSION}-slim AS runtime
 
-# ===== Final stage =====
-FROM base AS final
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH=/home/${APP_USER}/.local/bin:$PATH
+
+# minimal runtime deps
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user & group (use build args so CI can override if needed)
+RUN groupadd -g ${APP_GID} ${APP_USER} || true \
+ && useradd --uid ${APP_UID} --gid ${APP_GID} --create-home --shell /bin/sh ${APP_USER} || true
+
+WORKDIR /app
+
+# Copy site-packages installed by builder (we asked Poetry to install into system site-packages)
+COPY --from=builder /usr/local/lib/python${PYTHON_VERSION%.*}/site-packages /usr/local/lib/python${PYTHON_VERSION%.*}/site-packages
+COPY --from=builder /app /app
+
+# ensure ownership
+RUN chown -R ${APP_USER}:${APP_USER} /app
+
+# add a tiny entrypoint that handles signals
+COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER ${APP_USER}
+ENV HOME=/home/${APP_USER}
+
+EXPOSE 8000
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: build up down dev prod logs shell
+
+build:
+	docker compose -f docker-compose.yml build
+
+up:
+	docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+down:
+	docker compose down
+
+dev:
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+
+logs:
+	docker compose logs -f web
+
+shell:
+	docker compose exec bot sh

--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ A modern Telegram bot built with **Python**, **FastAPI**, **aiogram**, and **Pos
 
 ## Development Setup
 
+## Architecture
+- Python 3.11, FastAPI, aiogram
+- PostgreSQL for persistent storage
+- Docker multi-stage builds + Poetry-managed dependencies
 
-### Requirements
-- Python 3.11+
-- Docker & Docker Compose
+## Quickstart (Development)
+1. Copy configuration: `cp .env.example .env` and fill values (TELEGRAM_TOKEN, DATABASE_URL, ADMIN_CHAT_ID).
+2. Start dev environment (hot reload):  
+   `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build`
+3. Visit the REST API at `http://localhost:8000` and your bot in Telegram.
 
-
-### Run with Docker Compose
-```bash
-docker-compose up --build
+## Quickstart (Production)
+1. Build & run production images:
+   `docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d`
+2. Apply database migrations:
+   `docker compose exec web alembic upgrade head`  (if applicable)
 ```
-The bot will connect to Telegram and expose a REST API at http://localhost:8000.
 
-### Run locally
-```bash
-pip install -r requirements.txt
-cp .env.example .env  # fill in your TELEGRAM_TOKEN and DB details
-uvicorn app.main:app --reload
-```
 ### Database migrations
 ```bash
 alembic revision --autogenerate -m "init schema"
@@ -41,15 +41,20 @@ alembic upgrade head
 ```
 ## Contribution Guide
 
-We welcome contributions! Please:
+- See `CONTRIBUTING.md` for details. TL;DR:
+  - Tests required for new features.
+  - Document public API or bot commands in `docs/`.
+  - Use small, focused PRs.
 
-* Open an issue for discussion before major changes
+We welcome contributions! Please:
 
 * Follow PEP8 style guide
 
-* Run black, ruff, and mypy before committing
-
-* Write tests for new features
+## Development workflow (recommended)
+- Create an issue before major changes.
+- Open a feature branch `feature/short-description`.
+- Run formatters & linters before pushing: `black . && ruff check . && mypy .`
+- Create a Pull Request referencing the issue; request 1+ reviews.
 
 ## Security
 
@@ -58,6 +63,17 @@ We welcome contributions! Please:
 * Do not hardcode API keys or credentials
 
 * Use least privilege when deploying in production
+
+* Report security issues privately following `SECURITY.md`.
+
+## FAQ / Troubleshooting
+- If you get permission issues when mounting code in dev, set `UID`/`GID` env vars (e.g. `export UID=$(id -u) GID=$(id -g)`).
+
+## Community & Governance
+- Use GitHub Issues for bugs & feature requests.
+- Use Discussions (or a Telegram/Matrix room) for design conversations.
+- Maintain a `MAINTAINERS.md` and a `CODEOWNERS` file so community knows who to ping for reviews.
+
 
 ## Roadmap
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,13 @@
+services:
+  bot:
+    build:
+      args:
+        # In dev builds you can install dev deps by passing an arg, or simply rely on volume-mounted host venv
+        POETRY_INSTALL_DEV: "true"
+    volumes:
+      - ./:/app:cached
+    environment:
+      - PYTHONPATH=/app/src
+    command: uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+    # map host UID/GID to container (keeps file permissions correct)
+    user: "${UID:-1000}:${GID:-1000}"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,11 @@
+services:
+  bot:
+    image: jdinbot:latest
+    ports:
+      - "8000:8000"
+    environment:
+      - ENV=production
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 4
+    deploy:
+      restart_policy:
+        condition: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,16 +16,9 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # DEV_MODE is determined by environment variable, default true
-        DEV_MODE: "${DEV_MODE:-true}"
-    environment:
-      - ENV=${ENV:-development}
-    volumes:
-      # Only mount source code if in dev mode
-      - type: bind
-        source: .
-        target: /app
-        read_only: ${DEV_MODE:-true} != "false"  # pseudo logic
+         PYTHON_VERSION: "3.13"
+         POETRY_VERSION: "1.6.0"   # optional
+    image: jdinbot:latest
     depends_on:
       - postgres
     env_file:
@@ -33,6 +26,7 @@ services:
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     ports:
       - "8000:8000"
+    restart: unless-stopped
 
 volumes:
   pgdata:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+# simple entrypoint: propagate signals and run the command
+set -e
+
+# if mounted volume changed ownership, ensure /app is writable by the runtime user
+if [ "$(id -u)" = "0" ]; then
+  chown -R $(id -u ${APP_USER} 2>/dev/null || echo 1001):$(id -g ${APP_USER} 2>/dev/null || echo 1001) /app || true
+  exec su-exec ${APP_USER} "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
…on-root user, updated README

- Reworked Dockerfile into multi-stage build:
  - Builder installs dependencies via Poetry
  - Runtime image runs as non-root user (APP_USER, UID/GID configurable)
  - Smaller, more secure production image (no Poetry in final stage)
- Added docker-compose.yml (base) + overrides:
  - docker-compose.dev.yml with hot reload, volume mounts, UID/GID mapping
  - docker-compose.prod.yml with optimized prod settings
- Added docker/entrypoint.sh to handle signals and ownership safely
- Added Makefile with common targets (dev, prod, build, logs, shell)
- Updated README.md:
  - Clear Quickstart for dev and prod
  - Architecture overview
  - Contribution & community guidelines
  - Security notes and troubleshooting section
- Improves project security by removing root execution inside containers
- Provides a scalable base for future community-driven contributions

BREAKING CHANGE: replaces old Docker setup; contributors must rebuild with new docker-compose.* files.